### PR TITLE
Update app.yaml

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,6 +1,6 @@
 application: regex-golang
 version: 1
-runtime: go
+runtime: go114
 api_version: go1
 
 handlers:


### PR DESCRIPTION
Right now the service is down because Google dropped support for go 1.9.